### PR TITLE
Fix missing dotenv dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.6.0",
     "requests>=2.32.3",
+    "python-dotenv>=1.0.1",
 ]
 
 [[project.authors]]


### PR DESCRIPTION
## Summary
- fix packaging by adding python-dotenv dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`